### PR TITLE
Financial request

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'android.arch.core:core-testing:1.1.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/java/com/example/sep/BaseActivity.java
+++ b/app/src/main/java/com/example/sep/BaseActivity.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 
 
 import com.example.sep.database.Employees;
+import com.example.sep.database.FinancialRequestList;
 import com.example.sep.viewModel.RoleTransfer;
 import com.example.sep.database.EventList;
 
@@ -22,7 +23,12 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class BaseActivity extends AppCompatActivity {
 
+    /*------ SERILAIZATION -------*/
     public static EventList eventList; // referenced from everywhere, needs to be static
+    public static FinancialRequestList fRequestList;
+
+    public static String EVENT_LIST_FILE = "eventlist.ser";
+    public static String FIN_REQUEST_FILE = "finrequestlist.ser";
 
     BottomNavigationView bottomNavigationView;
     BottomNavigationView bottomNavigationViewFM;
@@ -102,7 +108,7 @@ public class BaseActivity extends AppCompatActivity {
                 return true;
             case R.id.nav_financial_requests:
                 // TODO: if financial manager, load financial request rv
-                loadFragment(new FragmentHome());
+                loadFragment(new FragmentFinancialRequestForm());
                 return true;
         }
         return false;

--- a/app/src/main/java/com/example/sep/BaseActivity.java
+++ b/app/src/main/java/com/example/sep/BaseActivity.java
@@ -108,7 +108,7 @@ public class BaseActivity extends AppCompatActivity {
                 return true;
             case R.id.nav_financial_requests:
                 // TODO: if financial manager, load financial request rv
-                loadFragment(new FragmentFinancialRequestForm());
+                loadFragment(new FragmentFinancialRequestsList());
                 return true;
         }
         return false;

--- a/app/src/main/java/com/example/sep/FragmentCreateEvent.java
+++ b/app/src/main/java/com/example/sep/FragmentCreateEvent.java
@@ -29,13 +29,12 @@ import java.io.ObjectOutputStream;
 public class FragmentCreateEvent extends Fragment {
 
     /*-------- HOOKS -----------*/
-    TextInputEditText etRecordNumber, etClientName, etEventType, etAttendees,
+    private TextInputEditText etRecordNumber, etClientName, etEventType, etAttendees,
                         etBudget, etDateFrom, etDateTo, etComments;
-    MaterialButton btnSubmit, btnCancel;
-    CheckBox cbDecorations, cbFood, cbParties, cbDrinks, cbPhoto;
+    private CheckBox cbDecorations, cbFood, cbParties, cbDrinks, cbPhoto;
 
     /*------- VARIABLES --------*/
-    boolean decorations, food, parties, drinks, photo = false;
+    private boolean decorations, food, parties, drinks, photo = false;
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -84,21 +83,21 @@ public class FragmentCreateEvent extends Fragment {
         View view = inflater.inflate(R.layout.fragment_create_event, container, false);
 
         /*-------- HOOKS -----------*/
-       etRecordNumber = view.findViewById(R.id.et_record_number);
-       etClientName = view.findViewById(R.id.et_client_name);
-       etEventType = view.findViewById(R.id.et_event_type);
-       etAttendees = view.findViewById(R.id.et_attendees);
-       etBudget = view.findViewById(R.id.et_expected_budget);
-       etDateTo = view.findViewById(R.id.et_to);
-       etDateFrom = view.findViewById(R.id.et_from);
-       etComments = view.findViewById(R.id.et_comments);
-       cbDecorations = view.findViewById(R.id.cb_decorations);
-       cbFood = view.findViewById(R.id.cb_food);
-       cbParties = view.findViewById(R.id.cb_parties);
-       cbDrinks = view.findViewById(R.id.cb_drinks);
-       cbPhoto = view.findViewById(R.id.cb_photo);
-       btnCancel = view.findViewById(R.id.btn_create_event_cancel);
-       btnSubmit = view.findViewById(R.id.btn_create_event_submit);
+        etRecordNumber = view.findViewById(R.id.et_record_number);
+        etClientName = view.findViewById(R.id.et_client_name);
+        etEventType = view.findViewById(R.id.et_event_type);
+        etAttendees = view.findViewById(R.id.et_attendees);
+        etBudget = view.findViewById(R.id.et_expected_budget);
+        etDateTo = view.findViewById(R.id.et_to);
+        etDateFrom = view.findViewById(R.id.et_from);
+        etComments = view.findViewById(R.id.et_comments);
+        cbDecorations = view.findViewById(R.id.cb_decorations);
+        cbFood = view.findViewById(R.id.cb_food);
+        cbParties = view.findViewById(R.id.cb_parties);
+        cbDrinks = view.findViewById(R.id.cb_drinks);
+        cbPhoto = view.findViewById(R.id.cb_photo);
+        MaterialButton btnCancel = view.findViewById(R.id.btn_create_event_cancel);
+        MaterialButton btnSubmit = view.findViewById(R.id.btn_create_event_submit);
 
        /*------ LISTENERS --------*/
         etDateFrom.setOnClickListener(v -> datePickerDialog(etDateFrom));
@@ -136,6 +135,7 @@ public class FragmentCreateEvent extends Fragment {
 
     private void submitEvent() {
         // TODO add safety feature if numbers emptySara
+        //TODO figure out how to make a refernceID/ record number
         Event newEvent = new Event(
                 "todoId",
                 String.valueOf(etRecordNumber.getText()),
@@ -161,7 +161,7 @@ public class FragmentCreateEvent extends Fragment {
     private void saveResultList(Event event) {
         BaseActivity.eventList.addEvent(event);
         try {
-            FileOutputStream fos = getActivity().openFileOutput("eventlist.ser", Context.MODE_PRIVATE);
+            FileOutputStream fos = getActivity().openFileOutput(BaseActivity.EVENT_LIST_FILE, Context.MODE_PRIVATE);
             ObjectOutputStream oos = new ObjectOutputStream(fos);
             oos.writeObject(BaseActivity.eventList);
             oos.close();

--- a/app/src/main/java/com/example/sep/FragmentEventDetails.java
+++ b/app/src/main/java/com/example/sep/FragmentEventDetails.java
@@ -3,6 +3,7 @@ package com.example.sep;
 import android.content.Context;
 import android.os.Bundle;
 
+import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
@@ -13,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
+import com.example.sep.databinding.FragmentEventDetailsBinding;
 import com.example.sep.model.Event;
 import com.example.sep.viewModel.EventViewModel;
 import com.example.sep.viewModel.RoleTransfer;
@@ -33,11 +35,11 @@ import java.util.Objects;
 public class FragmentEventDetails extends Fragment {
 
     /*__________ SAVING/DELETING __________*/
-    Integer itemIdentifier;
+    private int itemIdentifier;
 
-    Event event;
-    TextInputEditText etFMReview;
-    TextInputLayout tiFMReview;
+    private Event mEvent;
+    private TextInputEditText etFMReview;
+    private TextInputLayout tiFMReview;
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -83,23 +85,15 @@ public class FragmentEventDetails extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        View view = inflater.inflate(R.layout.fragment_event_details, container, false);
+        FragmentEventDetailsBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_event_details, container, false);
+        View view = binding.getRoot();
 
         /* ------- HOOKS --------*/
-        MaterialTextView tvRecordNumber = view.findViewById(R.id.tv_record_number_view2);
-        MaterialTextView tvClientName = view.findViewById(R.id.tv_client_name_view2);
-        MaterialTextView tvEventType = view.findViewById(R.id.tv_event_type_view2);
-        MaterialTextView tvFrem = view.findViewById(R.id.tv_from_view2);
-        MaterialTextView tvTo = view.findViewById(R.id.tv_to_view2);
-        MaterialTextView tvAttendees = view.findViewById(R.id.tv_attendees_view2);
-        MaterialTextView tvBudget = view.findViewById(R.id.tv_budget_view2);
         MaterialTextView tvApprovedBy = view.findViewById(R.id.tv_approved_by_view2);
         MaterialTextView tvFMReview = view.findViewById(R.id.tv_fm_review_view2);
-
         LinearLayout llFinancialManager = view.findViewById(R.id.ll_fm);
         etFMReview = view.findViewById(R.id.et_fm_review);
         tiFMReview = view.findViewById(R.id.ti_fm_review);
-
         MaterialButton btnDelete = view.findViewById(R.id.btn_event_details_delete);
         MaterialButton btnApprove = view.findViewById(R.id.btn_event_details_approve);
         MaterialButton btnReview = view.findViewById(R.id.btn_add_comment);
@@ -127,19 +121,14 @@ public class FragmentEventDetails extends Fragment {
         EventViewModel eventVM = new ViewModelProvider(requireActivity()).get(EventViewModel.class);
 
         /* ------- LISTENERS --------*/
-        eventVM.getEvent().observe(getActivity(), eventItem -> {
-            event = eventItem.getEvent();
+        eventVM.getEvent().observe(requireActivity(), event -> {
             if (event.getLevel() == 1 || event.getLevel() == 3) btnApprove.setEnabled(false);
-            itemIdentifier = eventItem.getIdx();
+            itemIdentifier = eventVM.getIdentifier();
+
+            binding.setEventVM(eventVM);
+            mEvent = event;
 
             /* ------ UI ---------*/
-            tvRecordNumber.setText(event.getRecordNumber());
-            tvClientName.setText(event.getClientName());
-            tvEventType.setText(event.getEventType());
-            tvFrem.setText(event.getFromDate());
-            tvTo.setText(event.getToDate());
-            tvAttendees.setText(String.valueOf(event.getAttendees()));
-            tvBudget.setText(String.valueOf(event.getBudget()));
             tvApprovedBy.setText(getApprovedBy(event.getLevel()));
             if (event.getLevel() > 1) tvFMReview.setText(event.getFMReview());
         });
@@ -155,14 +144,14 @@ public class FragmentEventDetails extends Fragment {
 
     private void onReview() {
         if (RoleTransfer.getRole().equals("Financial manager")) {
-            if (event != null) {
+            if (mEvent != null) {
                 if (Objects.equals(String.valueOf(etFMReview.getText()), "")) {
                     tiFMReview.setError("Required");
                     Toast.makeText(getActivity(), "Please review event", Toast.LENGTH_SHORT).show();
                 } else {
-                    event.setFMReview(String.valueOf(etFMReview.getText()));
-                    event.addLevel();
-                    BaseActivity.eventList.updateEvent(event, itemIdentifier);
+                    mEvent.setFMReview(String.valueOf(etFMReview.getText()));
+                    mEvent.addLevel();
+                    BaseActivity.eventList.updateEvent(mEvent, itemIdentifier);
 
                     //Update list in local storage
                     saveResultList();
@@ -185,9 +174,9 @@ public class FragmentEventDetails extends Fragment {
 
     private void onApprove() {
         if (RoleTransfer.getRole().equals("Senior Customer Service Officer") || RoleTransfer.getRole().equals("Administration department manager")) {
-            if (event != null) {
-                event.addLevel();
-                BaseActivity.eventList.updateEvent(event, itemIdentifier);
+            if (mEvent != null) {
+                mEvent.addLevel();
+                BaseActivity.eventList.updateEvent(mEvent, itemIdentifier);
 
                 //Update list in local storage
                 saveResultList();

--- a/app/src/main/java/com/example/sep/FragmentEventDetails.java
+++ b/app/src/main/java/com/example/sep/FragmentEventDetails.java
@@ -106,28 +106,20 @@ public class FragmentEventDetails extends Fragment {
 
         switch (RoleTransfer.getRole()) {
             case "Customer Service":
-                btnDelete.setVisibility(View.INVISIBLE);
-                btnApprove.setVisibility(View.INVISIBLE);
-                btnReview.setVisibility(View.INVISIBLE);
+                buttonVisibilitySetter(btnDelete, btnApprove, btnReview, View.INVISIBLE, View.INVISIBLE, View.INVISIBLE);
                 llFinancialManager.setVisibility(View.INVISIBLE);
                 break;
             case "Senior Customer Service Officer":
             case "Administration department manager":
-                btnDelete.setVisibility(View.VISIBLE);
-                btnApprove.setVisibility(View.VISIBLE);
-                btnReview.setVisibility(View.INVISIBLE);
+                buttonVisibilitySetter(btnDelete, btnApprove, btnReview, View.VISIBLE, View.VISIBLE, View.INVISIBLE);
                 llFinancialManager.setVisibility(View.INVISIBLE);
                 break;
             case "Financial manager":
-                btnDelete.setVisibility(View.INVISIBLE);
-                btnApprove.setVisibility(View.INVISIBLE);
-                btnReview.setVisibility(View.VISIBLE);
+                buttonVisibilitySetter(btnDelete, btnApprove, btnReview, View.INVISIBLE, View.INVISIBLE, View.VISIBLE);
                 llFinancialManager.setVisibility(View.VISIBLE);
                 break;
             default:
-                btnDelete.setVisibility(View.INVISIBLE);
-                btnApprove.setVisibility(View.INVISIBLE);
-                btnReview.setVisibility(View.INVISIBLE);
+                buttonVisibilitySetter(btnDelete, btnApprove, btnReview, View.INVISIBLE, View.INVISIBLE, View.INVISIBLE);
                 break;
         }
 
@@ -158,6 +150,8 @@ public class FragmentEventDetails extends Fragment {
 
         return view;
     }
+
+
 
     private void onReview() {
         if (RoleTransfer.getRole().equals("Financial manager")) {
@@ -214,7 +208,7 @@ public class FragmentEventDetails extends Fragment {
 
     private void saveResultList() {
         try {
-            FileOutputStream fos = getActivity().openFileOutput("eventlist.ser", Context.MODE_PRIVATE);
+            FileOutputStream fos = getActivity().openFileOutput(BaseActivity.EVENT_LIST_FILE, Context.MODE_PRIVATE);
             ObjectOutputStream oos = new ObjectOutputStream(fos);
             oos.writeObject(BaseActivity.eventList);
             oos.close();
@@ -227,5 +221,11 @@ public class FragmentEventDetails extends Fragment {
         FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();
         fragmentTransaction.replace(R.id.content_container, fragment, "");
         fragmentTransaction.commit();
+    }
+
+    private void buttonVisibilitySetter(MaterialButton btnDelete, MaterialButton btnApprove, MaterialButton btnReview, int view1, int view2, int view3) {
+        btnDelete.setVisibility(view1);
+        btnApprove.setVisibility(view2);
+        btnReview.setVisibility(view3);
     }
 }

--- a/app/src/main/java/com/example/sep/FragmentEventList.java
+++ b/app/src/main/java/com/example/sep/FragmentEventList.java
@@ -140,7 +140,8 @@ public class FragmentEventList extends Fragment {
             RecyclerView.ViewHolder viewHolder = (RecyclerView.ViewHolder) view.getTag();
             int position = viewHolder.getAdapterPosition();
             EventItem eventItem = itemList.get(position);
-            eventVM.setEvent(eventItem);
+            eventVM.setEvent(eventItem.getEvent());
+            eventVM.setIdentifier(eventItem.getIdx());
 
             loadFragment(new FragmentEventDetails());
         }

--- a/app/src/main/java/com/example/sep/FragmentEventList.java
+++ b/app/src/main/java/com/example/sep/FragmentEventList.java
@@ -29,10 +29,10 @@ import java.util.ArrayList;
  */
 public class FragmentEventList extends Fragment {
 
-    RecyclerView rv_events;
-    public ArrayList<EventItem> itemList;
-    EventViewModel eventVM;
-    FloatingActionButton fabAdd;
+    private RecyclerView rv_events;
+    private ArrayList<EventItem> itemList;
+    private EventViewModel eventVM;
+    private FloatingActionButton fabAdd;
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -112,7 +112,7 @@ public class FragmentEventList extends Fragment {
         int finalAccessLevel = accessLevel-1;
         eventListVM.getEvent().observe(requireActivity(), events -> {
             itemList = new ArrayList<>();
-            Integer i = 0;
+            int i = 0;
             for (Event singleEvent : events){
                 // add to the recyclerView only the events that the employee can view
                 if (singleEvent.getLevel() >= finalAccessLevel) {

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestDetails.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestDetails.java
@@ -1,12 +1,27 @@
 package com.example.sep;
 
+import android.content.Context;
 import android.os.Bundle;
 
+import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.example.sep.databinding.FragmentFinancialRequestDetailsBinding;
+import com.example.sep.model.FinancialRequest;
+import com.example.sep.viewModel.FinancialRequestViewModel;
+import com.example.sep.viewModel.RoleTransfer;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textview.MaterialTextView;
+
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -14,6 +29,11 @@ import android.view.ViewGroup;
  * create an instance of this fragment.
  */
 public class FragmentFinancialRequestDetails extends Fragment {
+
+    /*__________ SAVING/DELETING __________*/
+    private int itemIdentifier;
+
+    private FinancialRequest mRequest;
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -59,6 +79,65 @@ public class FragmentFinancialRequestDetails extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_financial_request_details, container, false);
+        FragmentFinancialRequestDetailsBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_financial_request_details, container, false);
+        View view = binding.getRoot();
+
+        /* ------- HOOKS --------*/
+        MaterialButton btnDelete = view.findViewById(R.id.btn_fin_request_details_delete);
+        MaterialButton btnApprove = view.findViewById(R.id.btn_fin_request_details_approve);
+
+        FinancialRequestViewModel financialRequestVM = new ViewModelProvider(requireActivity()).get(FinancialRequestViewModel.class);
+
+        financialRequestVM.getRequest().observe(requireActivity(), request -> {
+            binding.setRequestVM(financialRequestVM);
+            mRequest = request;
+            itemIdentifier = financialRequestVM.getIdentifier();
+        });
+
+        btnDelete.setOnClickListener(v -> onDelete());
+        btnApprove.setOnClickListener(v -> onApprove());
+
+        return view;
+    }
+
+    private void onApprove() {
+        //if (RoleTransfer.getRole().equals("Senior Customer Service Officer") || RoleTransfer.getRole().equals("Administration department manager")) {
+            if (mRequest != null) {
+                // TODO: approve request
+                //event.addLevel();
+                BaseActivity.fRequestList.updateEvent(mRequest, itemIdentifier);
+
+                //Update list in local storage
+                saveResultList();
+                Toast.makeText(getActivity(), "Event is approved", Toast.LENGTH_SHORT).show();
+                loadFragment(new FragmentFinancialRequestsList());
+            }
+        //}
+    }
+
+    private void onDelete() {
+        BaseActivity.fRequestList.deleteFinancialRequest(itemIdentifier);
+        //Update list in local storage
+        saveResultList();
+        Toast.makeText(getActivity(), "Request is deleted", Toast.LENGTH_SHORT).show();
+
+        loadFragment(new FragmentEventList());
+    }
+
+    private void saveResultList() {
+        try {
+            FileOutputStream fos = getActivity().openFileOutput(BaseActivity.FIN_REQUEST_FILE, Context.MODE_PRIVATE);
+            ObjectOutputStream oos = new ObjectOutputStream(fos);
+            oos.writeObject(BaseActivity.fRequestList);
+            oos.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadFragment(Fragment fragment) {
+        FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.content_container, fragment, "");
+        fragmentTransaction.commit();
     }
 }

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestDetails.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestDetails.java
@@ -1,0 +1,64 @@
+package com.example.sep;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link FragmentFinancialRequestDetails#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class FragmentFinancialRequestDetails extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public FragmentFinancialRequestDetails() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment FragmentFinancialRequestDetails.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static FragmentFinancialRequestDetails newInstance(String param1, String param2) {
+        FragmentFinancialRequestDetails fragment = new FragmentFinancialRequestDetails();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_financial_request_details, container, false);
+    }
+}

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
 
 import android.view.LayoutInflater;
 import android.view.View;
@@ -109,6 +110,7 @@ public class FragmentFinancialRequestForm extends Fragment {
             etReason.setText("");
         });
 
+        // TODO: make it so that the user can only choose its own department
         radioGroup.setOnCheckedChangeListener((radioGroup, i) -> {
             RadioButton radioButton = view.findViewById(i);
             chosenDepartment = String.valueOf(radioButton.getText());
@@ -137,7 +139,10 @@ public class FragmentFinancialRequestForm extends Fragment {
                 String.valueOf(etRequiredAmount.getText()),
                 String.valueOf(etReason.getText())
         );
-        //saveResultsList(newRequest);
+        saveResultsList(newRequest);
+        FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.content_container, new FragmentFinancialRequestsList(), "");
+        fragmentTransaction.commit();
     }
 
     private Boolean isFieldEmpty(String text) {
@@ -145,12 +150,12 @@ public class FragmentFinancialRequestForm extends Fragment {
         return text != null && text.length() > 1;
     }
 
-    private void saveResultList(FinancialRequest request) {
+    private void saveResultsList(FinancialRequest request) {
         BaseActivity.fRequestList.addFinancialRequest(request);
         try {
             FileOutputStream fos = getActivity().openFileOutput(BaseActivity.FIN_REQUEST_FILE, Context.MODE_PRIVATE);
             ObjectOutputStream oos = new ObjectOutputStream(fos);
-            oos.writeObject(BaseActivity.eventList);
+            oos.writeObject(BaseActivity.fRequestList);
             oos.close();
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
@@ -1,5 +1,6 @@
 package com.example.sep;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import androidx.fragment.app.Fragment;
@@ -7,6 +8,19 @@ import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.Toast;
+
+import com.example.sep.model.Event;
+import com.example.sep.model.FinancialRequest;
+import com.example.sep.utils.HelperFunctions;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -14,6 +28,13 @@ import android.view.ViewGroup;
  * create an instance of this fragment.
  */
 public class FragmentFinancialRequestForm extends Fragment {
+
+    /*-------- HOOKS -----------*/
+    private TextInputEditText etRecordNumber, etRequiredAmount, etReason;
+    private TextInputLayout tiRecordNumber, tiRequiredAmount, tiReason;
+    private RadioGroup radioGroup;
+
+    private String chosenDepartment = "Administration";
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -59,6 +80,80 @@ public class FragmentFinancialRequestForm extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_financial_request_form, container, false);
+        View view = inflater.inflate(R.layout.fragment_financial_request_form, container, false);
+
+        /*-------- HOOKS -----------*/
+        etRecordNumber = view.findViewById(R.id.et_financial_req_record_number);
+        etRequiredAmount = view.findViewById(R.id.et_required_amount);
+        etReason = view.findViewById(R.id.et_reason);
+        tiRecordNumber = view.findViewById(R.id.ti_financial_req_record_number);
+        tiRequiredAmount = view.findViewById(R.id.ti_required_amount);
+        tiReason = view.findViewById(R.id.ti_reason);
+        MaterialButton btnCancel = view.findViewById(R.id.btn_financial_request_cancel);
+        MaterialButton btnSubmit = view.findViewById(R.id.btn_financial_request_submit);
+        radioGroup = view.findViewById(R.id.radioGroup);
+
+        /*------ LISTENERS --------*/
+        btnSubmit.setOnClickListener(v -> {
+            if (!isFieldEmpty(String.valueOf(etRequiredAmount.getText()))) tiRequiredAmount.setError("Amount required");
+            if (!isFieldEmpty(String.valueOf(etReason.getText()))) tiReason.setError("Reason required");
+            else {
+                tiRequiredAmount.setError(null);
+                tiReason.setError(null);
+                submitRequest();
+            }
+        });
+        btnCancel.setOnClickListener(v -> {
+            etRecordNumber.setText("");
+            etRequiredAmount.setText("");
+            etReason.setText("");
+        });
+
+        radioGroup.setOnCheckedChangeListener((radioGroup, i) -> {
+            RadioButton radioButton = view.findViewById(i);
+            chosenDepartment = String.valueOf(radioButton.getText());
+        });
+
+        // removes error messages
+        etRequiredAmount.setOnKeyListener((view1, i, keyEvent) -> {
+            if (!isFieldEmpty(String.valueOf(etRequiredAmount.getText())))
+                tiRequiredAmount.setError(null);
+            return false;
+        });
+        etReason.setOnKeyListener((view1, i, keyEvent) -> {
+            if (!isFieldEmpty(String.valueOf(etReason.getText()))) tiReason.setError(null);
+            return false;
+        });
+
+        return view;
+    }
+
+    private void submitRequest() {
+        // Todo: take record number from event
+
+        FinancialRequest newRequest = new FinancialRequest(
+                String.valueOf(etRecordNumber.getText()),
+                chosenDepartment,
+                String.valueOf(etRequiredAmount.getText()),
+                String.valueOf(etReason.getText())
+        );
+        //saveResultsList(newRequest);
+    }
+
+    private Boolean isFieldEmpty(String text) {
+        // for error messages in text fields
+        return text != null && text.length() > 1;
+    }
+
+    private void saveResultList(FinancialRequest request) {
+        BaseActivity.fRequestList.addFinancialRequest(request);
+        try {
+            FileOutputStream fos = getActivity().openFileOutput(BaseActivity.FIN_REQUEST_FILE, Context.MODE_PRIVATE);
+            ObjectOutputStream oos = new ObjectOutputStream(fos);
+            oos.writeObject(BaseActivity.eventList);
+            oos.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestForm.java
@@ -1,0 +1,64 @@
+package com.example.sep;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link FragmentFinancialRequestForm#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class FragmentFinancialRequestForm extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public FragmentFinancialRequestForm() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment FragmentFinancialRequestForm.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static FragmentFinancialRequestForm newInstance(String param1, String param2) {
+        FragmentFinancialRequestForm fragment = new FragmentFinancialRequestForm();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_financial_request_form, container, false);
+    }
+}

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestsList.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestsList.java
@@ -1,0 +1,116 @@
+package com.example.sep;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.sep.model.FinancialRequest;
+import com.example.sep.view.financialRequestRecyclerView.FinancialRequestItem;
+import com.example.sep.view.financialRequestRecyclerView.FinancialRequestItemAdapter;
+import com.example.sep.viewModel.FinancialRequestListViewModel;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import java.util.ArrayList;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link FragmentFinancialRequestsList#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class FragmentFinancialRequestsList extends Fragment {
+
+    private RecyclerView rvRequests;
+    private ArrayList<FinancialRequestItem> itemList;
+    private FloatingActionButton fabAdd;
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public FragmentFinancialRequestsList() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment FragmentFinancialRequestsList.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static FragmentFinancialRequestsList newInstance(String param1, String param2) {
+        FragmentFinancialRequestsList fragment = new FragmentFinancialRequestsList();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_financial_requests_list, container, false);
+
+        /*------------ UI ------------*/
+        rvRequests = view.findViewById(R.id.rv_requests);
+        fabAdd = view.findViewById(R.id.fab_add_request);
+
+        // TODO: set who can add requests, see how this can be done
+        fabAdd.setVisibility(View.VISIBLE);
+
+        /*------------ VM ------------*/
+        FinancialRequestListViewModel requestsVM = new ViewModelProvider(requireActivity()).get(FinancialRequestListViewModel.class);
+
+        /*---------- LISTENERS ----------*/
+        requestsVM.getRequests().observe(requireActivity(), requests -> {
+            itemList = new ArrayList<>();
+            int i = 0;
+            for (FinancialRequest singleRequest : requests) {
+                itemList.add(new FinancialRequestItem(singleRequest, i));
+                i++;
+            }
+            FinancialRequestItemAdapter requestItemAdapter = new FinancialRequestItemAdapter(itemList);
+            rvRequests.setLayoutManager(new LinearLayoutManager(getActivity()));
+            rvRequests.setAdapter(requestItemAdapter);
+            //requestItemAdapter.setOnItemClickListener();
+        });
+
+        fabAdd.setOnClickListener(v -> {
+            loadFragment(new FragmentFinancialRequestForm());
+        });
+
+        return view;
+    }
+
+    private void loadFragment(Fragment fragment) {
+        FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.content_container, fragment, "");
+        fragmentTransaction.commit();
+    }
+}

--- a/app/src/main/java/com/example/sep/FragmentFinancialRequestsList.java
+++ b/app/src/main/java/com/example/sep/FragmentFinancialRequestsList.java
@@ -16,6 +16,7 @@ import com.example.sep.model.FinancialRequest;
 import com.example.sep.view.financialRequestRecyclerView.FinancialRequestItem;
 import com.example.sep.view.financialRequestRecyclerView.FinancialRequestItemAdapter;
 import com.example.sep.viewModel.FinancialRequestListViewModel;
+import com.example.sep.viewModel.FinancialRequestViewModel;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ public class FragmentFinancialRequestsList extends Fragment {
     private RecyclerView rvRequests;
     private ArrayList<FinancialRequestItem> itemList;
     private FloatingActionButton fabAdd;
+    private FinancialRequestViewModel requestVM;
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -86,6 +88,7 @@ public class FragmentFinancialRequestsList extends Fragment {
 
         /*------------ VM ------------*/
         FinancialRequestListViewModel requestsVM = new ViewModelProvider(requireActivity()).get(FinancialRequestListViewModel.class);
+        requestVM = new ViewModelProvider(requireActivity()).get(FinancialRequestViewModel.class);
 
         /*---------- LISTENERS ----------*/
         requestsVM.getRequests().observe(requireActivity(), requests -> {
@@ -98,7 +101,7 @@ public class FragmentFinancialRequestsList extends Fragment {
             FinancialRequestItemAdapter requestItemAdapter = new FinancialRequestItemAdapter(itemList);
             rvRequests.setLayoutManager(new LinearLayoutManager(getActivity()));
             rvRequests.setAdapter(requestItemAdapter);
-            //requestItemAdapter.setOnItemClickListener();
+            requestItemAdapter.setOnItemClickListener(onItemClickListener);
         });
 
         fabAdd.setOnClickListener(v -> {
@@ -107,6 +110,19 @@ public class FragmentFinancialRequestsList extends Fragment {
 
         return view;
     }
+
+    private final View.OnClickListener onItemClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            RecyclerView.ViewHolder viewHolder = (RecyclerView.ViewHolder) view.getTag();
+            int position = viewHolder.getAdapterPosition();
+            FinancialRequestItem requestItem = itemList.get(position);
+            requestVM.setRequest(requestItem.getRequest());
+            requestVM.setIdentifier(requestItem.getIdx());
+
+            loadFragment(new FragmentFinancialRequestDetails());
+        }
+    };
 
     private void loadFragment(Fragment fragment) {
         FragmentTransaction fragmentTransaction = getActivity().getSupportFragmentManager().beginTransaction();

--- a/app/src/main/java/com/example/sep/database/FinancialRequestList.java
+++ b/app/src/main/java/com/example/sep/database/FinancialRequestList.java
@@ -1,0 +1,24 @@
+package com.example.sep.database;
+
+import com.example.sep.model.FinancialRequest;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class FinancialRequestList implements Serializable {
+    private ArrayList<FinancialRequest> theRequests;
+
+    public FinancialRequestList() {}
+    public ArrayList<FinancialRequest> getTheRequests() {
+        if (theRequests == null) theRequests = new ArrayList<>();
+        return theRequests;
+    }
+
+    public void addFinancialRequest(FinancialRequest financialRequest) { theRequests.add(financialRequest); }
+    public void deleteFinancialRequest(Integer idx) { theRequests.remove(idx.intValue());}
+
+    public void updateEvent(FinancialRequest request, Integer idx) {
+        deleteFinancialRequest(idx);
+        addFinancialRequest(request);
+    }
+}

--- a/app/src/main/java/com/example/sep/database/FinancialRequestList.java
+++ b/app/src/main/java/com/example/sep/database/FinancialRequestList.java
@@ -9,6 +9,7 @@ public class FinancialRequestList implements Serializable {
     private ArrayList<FinancialRequest> theRequests;
 
     public FinancialRequestList() {}
+
     public ArrayList<FinancialRequest> getTheRequests() {
         if (theRequests == null) theRequests = new ArrayList<>();
         return theRequests;

--- a/app/src/main/java/com/example/sep/model/FinancialRequest.java
+++ b/app/src/main/java/com/example/sep/model/FinancialRequest.java
@@ -1,0 +1,47 @@
+package com.example.sep.model;
+
+import java.io.Serializable;
+
+public class FinancialRequest implements Serializable {
+
+    String projectReference, requestingDepartment, requiredAmount, reason;
+
+    public FinancialRequest(String projectRef, String department, String amount, String reason) {
+        this.projectReference = projectRef;
+        this.requestingDepartment = department;
+        this.requiredAmount = amount;
+        this.reason = reason;
+    }
+
+    public String getProjectReference() {
+        return projectReference;
+    }
+
+    public void setProjectReference(String projectReference) {
+        this.projectReference = projectReference;
+    }
+
+    public String getRequestingDepartment() {
+        return requestingDepartment;
+    }
+
+    public void setRequestingDepartment(String requestingDepartment) {
+        this.requestingDepartment = requestingDepartment;
+    }
+
+    public String getRequiredAmount() {
+        return requiredAmount;
+    }
+
+    public void setRequiredAmount(String requiredAmount) {
+        this.requiredAmount = requiredAmount;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/app/src/main/java/com/example/sep/view/eventRecyclerView/EventItem.java
+++ b/app/src/main/java/com/example/sep/view/eventRecyclerView/EventItem.java
@@ -5,7 +5,7 @@ import com.example.sep.model.Event;
 import java.io.Serializable;
 
 public class EventItem implements Serializable {
-    Integer idx;
+    int idx;
     Event iEvent;
 
     String iClientName;

--- a/app/src/main/java/com/example/sep/view/eventRecyclerView/EventItem.java
+++ b/app/src/main/java/com/example/sep/view/eventRecyclerView/EventItem.java
@@ -9,9 +9,9 @@ public class EventItem implements Serializable {
     Event iEvent;
 
     String iClientName;
-    Integer iLevel;
+    int iLevel;
 
-    public EventItem(Event event, Integer idx) {
+    public EventItem(Event event, int idx) {
         iEvent = event;
 
         iClientName = event.getClientName();
@@ -23,11 +23,11 @@ public class EventItem implements Serializable {
     public String getClientName(){
         return iClientName;
     }
-    public Integer getLevel() { return iLevel; }
+    public int getLevel() { return iLevel; }
 
     public Event getEvent(){
         return iEvent;
     }
 
-    public Integer getIdx(){return idx;}
+    public int getIdx(){return idx;}
 }

--- a/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItem.java
+++ b/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItem.java
@@ -3,11 +3,17 @@ package com.example.sep.view.financialRequestRecyclerView;
 import com.example.sep.model.FinancialRequest;
 
 public class FinancialRequestItem {
-    int idx;
-    FinancialRequest iRequest;
+    private int idx;
+    private FinancialRequest iRequest;
+    
+    private String iAmount, iDepartment;
 
     public FinancialRequestItem(FinancialRequest request, int idx) {
         iRequest = request;
+        
+        iDepartment = request.getRequestingDepartment();
+        iAmount = request.getRequiredAmount();
+        
         this.idx = idx;
     }
 
@@ -15,7 +21,15 @@ public class FinancialRequestItem {
         return idx;
     }
 
-    public FinancialRequest getiRequest() {
+    public String getAmount() {
+        return iAmount;
+    }
+
+    public String getDepartment() {
+        return iDepartment;
+    }
+
+    public FinancialRequest getRequest() {
         return iRequest;
     }
 }

--- a/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItem.java
+++ b/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItem.java
@@ -1,0 +1,21 @@
+package com.example.sep.view.financialRequestRecyclerView;
+
+import com.example.sep.model.FinancialRequest;
+
+public class FinancialRequestItem {
+    int idx;
+    FinancialRequest iRequest;
+
+    public FinancialRequestItem(FinancialRequest request, int idx) {
+        iRequest = request;
+        this.idx = idx;
+    }
+
+    public int getIdx() {
+        return idx;
+    }
+
+    public FinancialRequest getiRequest() {
+        return iRequest;
+    }
+}

--- a/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItemAdapter.java
+++ b/app/src/main/java/com/example/sep/view/financialRequestRecyclerView/FinancialRequestItemAdapter.java
@@ -1,0 +1,58 @@
+package com.example.sep.view.financialRequestRecyclerView;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.sep.R;
+
+import java.util.ArrayList;
+
+public class FinancialRequestItemAdapter extends RecyclerView.Adapter<FinancialRequestItemAdapter.FinancialRequestViewHolder> {
+    public ArrayList<FinancialRequestItem> mRequestItem;
+    private View.OnClickListener mOnItemClickListener;
+
+    @NonNull
+    @Override
+    public FinancialRequestItemAdapter.FinancialRequestViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View lv = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.cell_financial_request, parent, false);
+        return new FinancialRequestItemAdapter.FinancialRequestViewHolder(lv);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull FinancialRequestItemAdapter.FinancialRequestViewHolder holder, int position) {
+
+        holder.iDepartment.setText(mRequestItem.get(position).getDepartment());
+        holder.iAmount.setText(mRequestItem.get(position).getAmount());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mRequestItem.size();
+    }
+
+
+    public class FinancialRequestViewHolder extends RecyclerView.ViewHolder{
+        public TextView iDepartment, iAmount;
+        public FinancialRequestViewHolder(@NonNull View itemView) {
+            super(itemView);
+            iDepartment = itemView.findViewById(R.id.tv_fin_request_department);
+            iAmount = itemView.findViewById(R.id.tv_fin_request_amount);
+
+            itemView.setTag(this);
+            itemView.setOnClickListener(mOnItemClickListener);
+        }
+    }
+    public FinancialRequestItemAdapter(ArrayList<FinancialRequestItem> requestItem) {
+        mRequestItem = requestItem;
+    }
+
+    public void setOnItemClickListener(View.OnClickListener itemClickListener){
+        mOnItemClickListener = itemClickListener;
+    }
+}

--- a/app/src/main/java/com/example/sep/viewModel/EventListViewModel.java
+++ b/app/src/main/java/com/example/sep/viewModel/EventListViewModel.java
@@ -37,7 +37,7 @@ public class EventListViewModel extends AndroidViewModel {
         // asynchronous call to load the event
         //Deserialise eventslist here
         try{
-            FileInputStream fin = getApplication().getApplicationContext().openFileInput("eventlist.ser");
+            FileInputStream fin = getApplication().getApplicationContext().openFileInput(BaseActivity.EVENT_LIST_FILE);
             ObjectInputStream oin = new ObjectInputStream(fin);
             BaseActivity.eventList = (EventList) oin.readObject();
             events.setValue(BaseActivity.eventList.getTheEvents());

--- a/app/src/main/java/com/example/sep/viewModel/EventViewModel.java
+++ b/app/src/main/java/com/example/sep/viewModel/EventViewModel.java
@@ -11,23 +11,26 @@ public class EventViewModel extends ViewModel {
 
     // TODO: see if it can be refactored for Event instead of eventItem
 
-    public MutableLiveData<EventItem> event;
-    public LiveData<EventItem> getEvent() {
+    public MutableLiveData<Event> event;
+    public int identifier;
+
+    public LiveData<Event> getEvent() {
         if(event == null) {
             event = new MutableLiveData<>();
-            loadEvent();
         }
         return event;
     }
 
-    private void loadEvent() {
-        // asynchronous call to load the event
-    }
-
-    public void setEvent(EventItem eventObj) {
+    public void setEvent(Event eventObj) {
         if(event == null) {
             event = new MutableLiveData<>();
         }
         event.postValue(eventObj);
     }
+
+    public void setIdentifier(int idx) {
+        identifier = idx;
+    }
+
+    public int getIdentifier() { return identifier; }
 }

--- a/app/src/main/java/com/example/sep/viewModel/FinancialRequestListViewModel.java
+++ b/app/src/main/java/com/example/sep/viewModel/FinancialRequestListViewModel.java
@@ -1,0 +1,49 @@
+package com.example.sep.viewModel;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.example.sep.BaseActivity;
+import com.example.sep.database.FinancialRequestList;
+import com.example.sep.model.FinancialRequest;
+
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
+import java.util.List;
+
+public class FinancialRequestListViewModel extends AndroidViewModel {
+    public FinancialRequestListViewModel(@NonNull Application application) {
+        super(application);
+    }
+
+    public MutableLiveData<List<FinancialRequest>> requests;
+
+    public LiveData<List<FinancialRequest>> getRequests() {
+        if (requests == null) {
+            requests = new MutableLiveData<>();
+            loadRequests();
+        }
+        return requests;
+    }
+
+    private void loadRequests() {
+        // asynchronous call to load the event
+        //Deserialise eventslist here
+        try{
+            FileInputStream fin = getApplication().getApplicationContext().openFileInput(BaseActivity.FIN_REQUEST_FILE);
+            ObjectInputStream oin = new ObjectInputStream(fin);
+            BaseActivity.fRequestList = (FinancialRequestList) oin.readObject();
+            requests.setValue(BaseActivity.fRequestList.getTheRequests());
+            oin.close();
+
+        } catch (Exception e){
+            e.printStackTrace();
+            BaseActivity.fRequestList = new FinancialRequestList();
+            requests.setValue(BaseActivity.fRequestList.getTheRequests());
+        }
+    }
+}

--- a/app/src/main/java/com/example/sep/viewModel/FinancialRequestViewModel.java
+++ b/app/src/main/java/com/example/sep/viewModel/FinancialRequestViewModel.java
@@ -1,2 +1,33 @@
-package com.example.sep.viewModel;public class FinancialRequestViewModel {
+package com.example.sep.viewModel;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.example.sep.model.FinancialRequest;
+
+public class FinancialRequestViewModel extends ViewModel {
+
+    public MutableLiveData<FinancialRequest> request;
+    public int identifier;
+
+    public LiveData<FinancialRequest> getRequest() {
+        if (request == null) {
+            request = new MutableLiveData<>();
+        }
+        return request;
+    }
+
+    public void setRequest(FinancialRequest requestObj) {
+        if (request == null) {
+            request = new MutableLiveData<>();
+        }
+        request.postValue(requestObj);
+    }
+
+    public void setIdentifier(int idx) {
+        identifier = idx;
+    }
+
+    public int getIdentifier() { return identifier; }
 }

--- a/app/src/main/java/com/example/sep/viewModel/FinancialRequestViewModel.java
+++ b/app/src/main/java/com/example/sep/viewModel/FinancialRequestViewModel.java
@@ -1,0 +1,2 @@
+package com.example.sep.viewModel;public class FinancialRequestViewModel {
+}

--- a/app/src/main/res/drawable/ic_baseline_attach_money_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_attach_money_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.8,10.9c-2.27,-0.59 -3,-1.2 -3,-2.15 0,-1.09 1.01,-1.85 2.7,-1.85 1.78,0 2.44,0.85 2.5,2.1h2.21c-0.07,-1.72 -1.12,-3.3 -3.21,-3.81V3h-3v2.16c-1.94,0.42 -3.5,1.68 -3.5,3.61 0,2.31 1.91,3.46 4.7,4.13 2.5,0.6 3,1.48 3,2.41 0,0.69 -0.49,1.79 -2.7,1.79 -2.06,0 -2.87,-0.92 -2.98,-2.1h-2.2c0.12,2.19 1.76,3.42 3.68,3.83V21h3v-2.15c1.95,-0.37 3.5,-1.5 3.5,-3.55 0,-2.84 -2.43,-3.81 -4.7,-4.4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_event_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_event_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,12h-5v5h5v-5zM16,1v2L8,3L8,1L6,1v2L5,3c-1.11,0 -1.99,0.9 -1.99,2L3,19c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2h-1L18,1h-2zM19,19L5,19L5,8h14v11z"/>
+</vector>

--- a/app/src/main/res/drawable/selector.xml
+++ b/app/src/main/res/drawable/selector.xml
@@ -6,7 +6,7 @@
         android:color="?colorOnPrimary" />
 
     <item
-        android:state_selected="true"
+        android:state_selected="false"
         android:color="?colorOnSecondary" />
 
 </selector>

--- a/app/src/main/res/layout/activity_base.xml
+++ b/app/src/main/res/layout/activity_base.xml
@@ -74,6 +74,24 @@
 
             app:labelVisibilityMode="labeled"/>
 
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation_fm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+
+            app:menu="@menu/bottom_nav_menu_fm"
+
+            app:itemIconTint="@drawable/selector"
+            app:itemTextColor="@drawable/selector"
+            android:background="?colorPrimary"
+
+            app:labelVisibilityMode="labeled"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/cell_financial_request.xml
+++ b/app/src/main/res/layout/cell_financial_request.xml
@@ -15,7 +15,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/tv_cell_client_name"
+            android:id="@+id/tv_fin_request_department"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -23,7 +23,7 @@
             android:text="@string/event" />
 
         <TextView
-            android:id="@+id/tv_cell_level"
+            android:id="@+id/tv_fin_request_amount"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"

--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".FragmentEventDetails">
+    <data>
+        <variable name="eventVM" type="com.example.sep.viewModel.EventViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -47,7 +48,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_record_number_view2"
-                    android:text="@string/record_number"
+                    android:text="@{eventVM.event.recordNumber}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -61,7 +62,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_client_name_view2"
-                    android:text="@string/client_name"
+                    android:text="@{eventVM.event.clientName}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -75,7 +76,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_event_type_view2"
-                    android:text="@string/event_type"
+                    android:text="@{eventVM.event.eventType}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -89,7 +90,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_from_view2"
-                    android:text="@string/from"
+                    android:text="@{eventVM.event.fromDate}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -103,7 +104,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_to_view2"
-                    android:text="@string/to"
+                    android:text="@{eventVM.event.toDate}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -117,7 +118,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_attendees_view2"
-                    android:text="@string/attendees"
+                    android:text="@{String.valueOf(eventVM.event.attendees)}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -131,7 +132,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_budget_view2"
-                    android:text="@string/sek"
+                    android:text="@{String.valueOf(eventVM.event.budget)}"
                     android:padding="4dp"/>
 
             </TableRow>
@@ -252,4 +253,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_financial_request_details.xml
+++ b/app/src/main/res/layout/fragment_financial_request_details.xml
@@ -1,14 +1,144 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".FragmentFinancialRequestDetails">
+    <data>
+        <variable name="requestVM" type="com.example.sep.viewModel.FinancialRequestViewModel"/>
+    </data>
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_height="match_parent" >
 
-</FrameLayout>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_fin_request_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/financial_request_details"
+            android:textAlignment="center"
+            android:textSize="20sp"
+
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <TableLayout
+            android:id="@+id/table_fin_request_details"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:stretchColumns="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_fin_request_details">
+
+            <TableRow
+                android:gravity="center">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_record_number_fin_view"
+                    android:text="@string/record_number"
+                    android:padding="4dp"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_record_number_fin_view2"
+                    android:text="@{requestVM.request.projectReference}"
+                    android:padding="4dp"/>
+
+            </TableRow>
+            <TableRow
+                android:gravity="center">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_department_fin_view"
+                    android:text="@string/requesting_department"
+                    android:padding="4dp"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_department_fin_view2"
+                    android:text="@{requestVM.request.requestingDepartment}"
+                    android:padding="4dp"/>
+
+            </TableRow>
+            <TableRow
+                android:gravity="center">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_required_amount_fin_view"
+                    android:text="@string/required_amount"
+                    android:padding="4dp"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_required_amount_fin_view2"
+                    android:text="@{requestVM.request.requiredAmount}"
+                    android:padding="4dp"/>
+
+            </TableRow>
+
+            <TableRow
+                android:gravity="center">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_reason_fin_view"
+                    android:text="@string/reason"
+                    android:padding="4dp"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_reason_fin_view2"
+                    android:text="@{requestVM.request.reason}"
+                    android:padding="4dp"/>
+
+            </TableRow>
+
+            <TableRow
+                android:gravity="center">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_approved_by_fin_view"
+                    android:text="@string/status"
+                    android:padding="4dp"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_approved_by_fin_view2"
+                    android:text="@string/pending"
+                    android:padding="4dp"/>
+
+            </TableRow>
+
+        </TableLayout>
+
+        <!-- view for financial department -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_fin_request_details_delete"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/delete"
+            app:layout_constraintEnd_toStartOf="@id/btn_fin_request_details_approve"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="8dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/table_fin_request_details"
+            app:cornerRadius="20dp"
+            android:backgroundTint="?colorSecondary"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_fin_request_details_approve"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/approve"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_fin_request_details_delete"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/table_fin_request_details"
+            app:cornerRadius="20dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</layout>

--- a/app/src/main/res/layout/fragment_financial_request_details.xml
+++ b/app/src/main/res/layout/fragment_financial_request_details.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FragmentFinancialRequestDetails">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_financial_request_form.xml
+++ b/app/src/main/res/layout/fragment_financial_request_form.xml
@@ -61,7 +61,7 @@
                         android:id="@+id/rb_administration"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:checked="false"
+                        android:checked="true"
                         android:text="@string/administration"
                         android:textAlignment="viewStart" />
                     <RadioButton
@@ -124,7 +124,7 @@
                     android:text="@string/required_amount"/>
 
                 <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/ti_client_name"
+                    android:id="@+id/ti_required_amount"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:boxBackgroundMode="filled"
@@ -133,7 +133,7 @@
                     android:hint="@string/sek">
 
                     <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/et_client_name"
+                        android:id="@+id/et_required_amount"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="number"
@@ -147,11 +147,11 @@
             <TableRow
                 android:gravity="center">
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/tv_event_type"
+                    android:id="@+id/tv_reason"
                     android:text="@string/reason"/>
 
                 <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/ti_event_type"
+                    android:id="@+id/ti_reason"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="4dp"
@@ -160,7 +160,7 @@
                     android:hint="@string/reason">
 
                     <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/et_event_type"
+                        android:id="@+id/et_reason"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="text"

--- a/app/src/main/res/layout/fragment_financial_request_form.xml
+++ b/app/src/main/res/layout/fragment_financial_request_form.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".FragmentCreateEvent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_financial_request"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/financial_request"
+            android:textAlignment="center"
+            android:textSize="20sp"
+
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+
+        <TableLayout
+            android:id="@+id/table_financial_request"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:stretchColumns="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_financial_request">
+
+            <TableRow
+                android:gravity="center"
+                android:background="@drawable/table_border">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_requesting_dep"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="4dp"
+                    android:text="@string/requesting_department" />
+
+                <!--displaying a radio group on below line-->
+                <RadioGroup
+                    android:id="@+id/radioGroup"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="4dp">
+
+                    <!--adding a radio button -->
+                    <RadioButton
+                        android:id="@+id/rb_administration"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:text="@string/administration"
+                        android:textAlignment="viewStart" />
+                    <RadioButton
+                        android:id="@+id/rb_financial"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:text="@string/financial"
+                        android:textAlignment="viewStart" />
+                    <RadioButton
+                        android:id="@+id/rb_production"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:text="@string/production"
+                        android:textAlignment="viewStart" />
+                    <RadioButton
+                        android:id="@+id/rb_services"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:text="@string/services"
+                        android:textAlignment="viewStart" />
+
+                </RadioGroup>
+
+            </TableRow>
+
+            <TableRow
+                android:gravity="center">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_financial_req_record_number"
+                    android:text="@string/record_number"/>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/ti_financial_req_record_number"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="?colorPrimaryVariant"
+                    android:padding="4dp"
+                    android:hint="@string/record_number">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_financial_req_record_number"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </TableRow>
+
+            <TableRow
+                android:gravity="center">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_required_amount"
+                    android:text="@string/required_amount"/>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/ti_client_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="?colorPrimaryVariant"
+                    android:padding="4dp"
+                    android:hint="@string/sek">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_client_name"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number"
+                        android:maxLines="1"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </TableRow>
+
+            <TableRow
+                android:gravity="center">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv_event_type"
+                    android:text="@string/reason"/>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/ti_event_type"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="4dp"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="?colorPrimaryVariant"
+                    android:hint="@string/reason">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_event_type"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </TableRow>
+
+
+        </TableLayout>
+
+
+
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_financial_request_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel"
+            app:layout_constraintEnd_toStartOf="@id/btn_financial_request_submit"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="8dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/table_financial_request"
+            app:cornerRadius="20dp"
+            android:backgroundTint="?colorSecondary"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_financial_request_submit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/submit"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_financial_request_cancel"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/table_financial_request"
+            app:cornerRadius="20dp"/>
+
+        <Space
+            app:layout_constraintTop_toBottomOf="@id/btn_financial_request_cancel"
+            android:layout_width="match_parent"
+            android:layout_height="16dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_financial_requests_list.xml
+++ b/app/src/main/res/layout/fragment_financial_requests_list.xml
@@ -4,10 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".FragmentEventList">
+    tools:context=".FragmentFinancialRequestsList">
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_events"
+        android:id="@+id/rv_requests"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginStart="16dp"
@@ -23,13 +23,13 @@
     </androidx.recyclerview.widget.RecyclerView>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fab_add"
+        android:id="@+id/fab_add_request"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:visibility="invisible"
         android:src="@drawable/ic_baseline_add_24"
-        android:contentDescription="@string/create_event"
+        android:contentDescription="@string/create_financial_request"
         android:layout_margin="16dp" />
 
 </FrameLayout>

--- a/app/src/main/res/menu/bottom_nav_menu_fm.xml
+++ b/app/src/main/res/menu/bottom_nav_menu_fm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/nav_events"
+        android:icon="@drawable/ic_baseline_event_24"
+        android:title="@string/events" />
+
+    <item
+        android:id="@+id/nav_financial_requests"
+        android:icon="@drawable/ic_baseline_attach_money_24"
+        android:title="@string/financial_requests" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,5 +54,15 @@
     <string name="approved_by">Approved by</string>
     <string name="fm_review">FM review</string>
     <string name="not_yet_reviewed">not yet reviewed</string>
+    <string name="events">Events</string>
+    <string name="financial_requests">Financial requests</string>
+    <string name="financial_request">Financial request</string>
+    <string name="requesting_department">Requesting\ndepartment</string>
+    <string name="administration">Administration</string>
+    <string name="financial">Financial</string>
+    <string name="production">Production</string>
+    <string name="services">Services</string>
+    <string name="required_amount">Required amount</string>
+    <string name="reason">Reason</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,5 +65,9 @@
     <string name="required_amount">Required amount</string>
     <string name="reason">Reason</string>
     <string name="create_financial_request">Create Financial request</string>
+    <string name="financial_request_details">Financial request details</string>
+    <string name="department">Department</string>
+    <string name="status">Status</string>
+    <string name="pending">Pending</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,5 +64,6 @@
     <string name="services">Services</string>
     <string name="required_amount">Required amount</string>
     <string name="reason">Reason</string>
+    <string name="create_financial_request">Create Financial request</string>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/salmon_900</item>
         <item name="colorOnSecondary">@color/dark_grey</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/test/java/com/example/sep/TestVariables.java
+++ b/app/src/test/java/com/example/sep/TestVariables.java
@@ -1,0 +1,57 @@
+package com.example.sep;
+
+import com.example.sep.model.Event;
+
+public class TestVariables {
+    public static Event event1 = new Event(
+            "id",
+            "utzftzuf",
+            "client1",
+            "party",
+            "2022-03-12",
+            "2022-03-13",
+            "some comment",
+            234,
+            10000,
+            true,
+            true,
+            true,
+            false,
+            false,
+            0
+    );
+    public static Event event2 = new Event(
+            "id2",
+            "hfg",
+            "client2",
+            "seminar",
+            "2022-04-12",
+            "2022-04-13",
+            "other comment",
+            342,
+            50000,
+            false,
+            false,
+            false,
+            true,
+            true,
+            0
+    );
+
+    public static Event event = new Event(
+            "id",
+            "recordNumber",
+            "clientName",
+            "eventType",
+            "fromDate",
+            "toDate",
+            "comments",
+            10,
+            1000,
+            false,
+            true,
+            true,
+            true,
+            false,
+            0);
+}

--- a/app/src/test/java/com/example/sep/database/EmployeesTest.java
+++ b/app/src/test/java/com/example/sep/database/EmployeesTest.java
@@ -5,18 +5,22 @@ import static org.junit.Assert.assertNotEquals;
 
 import com.example.sep.model.Employee;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 
 public class EmployeesTest {
+    Employees cEmployees;
+
+    @Before
+    public void init() {
+        cEmployees = new Employees();
+        cEmployees.initEmployees();
+    }
 
     @Test
     public void getEmployees() {
-
-        // init
-        Employees cEmployees = new Employees();
-        cEmployees.initEmployees();
         ArrayList<Employee> employees = cEmployees.getEmployees();
 
         assertEquals(employees.get(0).getName(), "Janet");
@@ -31,9 +35,6 @@ public class EmployeesTest {
     @Test
     public void getEmployeesFromDb() {
 
-        // init
-        Employees cEmployees = new Employees();
-        cEmployees.initEmployees();
         Employee employee = cEmployees.getEmployeeFromDb("Janet");
 
         assertEquals(employee.getName(), "Janet");

--- a/app/src/test/java/com/example/sep/database/EventListTest.java
+++ b/app/src/test/java/com/example/sep/database/EventListTest.java
@@ -2,74 +2,39 @@ package com.example.sep.database;
 
 import static org.junit.Assert.*;
 
+import com.example.sep.TestVariables;
 import com.example.sep.model.Event;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class EventListTest {
 
-    EventList cEventList = new EventList();
+    // variables
+    EventList cEventList;
 
-    // init
-    Event event1 = new Event(
-            "id",
-            "utzftzuf",
-            "client1",
-            "party",
-            "2022-03-12",
-            "2022-03-13",
-            "some comment",
-            234,
-            10000,
-            true,
-            true,
-            true,
-            false,
-            false,
-            0
-    );
-    Event event2 = new Event(
-            "id2",
-            "hfg",
-            "client2",
-            "seminar",
-            "2022-04-12",
-            "2022-04-13",
-            "other comment",
-            342,
-            50000,
-            false,
-            false,
-            false,
-            true,
-            true,
-            0
-    );
-
+    @Before
     public void initList() {
+        cEventList = new EventList();
         cEventList.getTheEvents();
-        cEventList.addEvent(event1);
-        cEventList.addEvent(event2);
     }
 
     @Test
     public void addEventTest() {
-        initList();
-
+        cEventList.addEvent(TestVariables.event1);
+        cEventList.addEvent(TestVariables.event2);
         assertEquals(cEventList.getTheEvents().size(), 2);
     }
 
     @Test
     public void getTheEventsTest() {
-        initList();
-
+        addEventTest();
         assertEquals(cEventList.getTheEvents().get(1).getId(), "id2");
     }
 
     @Test
     public void deleteEvent() {
-        initList();
-
+        addEventTest();
         cEventList.deleteEvent(1);
 
         assertEquals(cEventList.getTheEvents().size(), 1);

--- a/app/src/test/java/com/example/sep/model/EventTest.java
+++ b/app/src/test/java/com/example/sep/model/EventTest.java
@@ -2,28 +2,15 @@ package com.example.sep.model;
 
 import static org.junit.Assert.*;
 
+import com.example.sep.TestVariables;
+
 import org.junit.Test;
 
 public class EventTest {
 
     @Test
     public void createEvent() {
-        Event event = new Event(
-                "id",
-                "recordNumber",
-                "clientName",
-                "eventType",
-                "fromDate",
-                "toDate",
-                "comments",
-                10,
-                1000,
-                false,
-                true,
-                true,
-                true,
-                false,
-                0);
+        Event event = TestVariables.event;
         assertEquals(event.getId(), "id");
         assertEquals(event.getRecordNumber(), "recordNumber");
         assertEquals(event.getEventType(), "eventType");

--- a/app/src/test/java/com/example/sep/view/eventRecyclerView/EventItemAdapterTest.java
+++ b/app/src/test/java/com/example/sep/view/eventRecyclerView/EventItemAdapterTest.java
@@ -1,0 +1,31 @@
+package com.example.sep.view.eventRecyclerView;
+
+import static org.junit.Assert.*;
+
+import com.example.sep.TestVariables;
+import com.example.sep.model.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class EventItemAdapterTest {
+
+    EventItemAdapter eventItem;
+
+    @Before
+    public void init() {
+        ArrayList<EventItem> eventArrayList = new ArrayList<>();
+        EventItem eventItem1 = new EventItem(TestVariables.event1, 0);
+        EventItem eventItem2 = new EventItem(TestVariables.event2, 1);
+        eventArrayList.add(eventItem1);
+        eventArrayList.add(eventItem2);
+        eventItem = new EventItemAdapter(eventArrayList);
+    }
+
+    @Test
+    public void getItemCountTest() {
+        assertEquals(eventItem.getItemCount(), 2);
+    }
+}

--- a/app/src/test/java/com/example/sep/view/eventRecyclerView/EventItemTest.java
+++ b/app/src/test/java/com/example/sep/view/eventRecyclerView/EventItemTest.java
@@ -1,0 +1,42 @@
+package com.example.sep.view.eventRecyclerView;
+
+import static org.junit.Assert.*;
+
+import com.example.sep.TestVariables;
+import com.example.sep.model.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class EventItemTest {
+
+    EventItem eventItem1, eventItem2;
+
+    @Before
+    public void init() {
+        eventItem1 = new EventItem(TestVariables.event1, 0);
+        eventItem2 = new EventItem(TestVariables.event2, 1);
+    }
+
+    @Test
+    public void getClientName() {
+        assertEquals(eventItem1.getClientName(), "client1");
+    }
+
+    @Test
+    public void getLevel() {
+        assertEquals(eventItem1.getLevel(), 0);
+    }
+
+    @Test
+    public void getEvent() {
+        assertEquals(eventItem1.getEvent(), TestVariables.event1);
+        assertEquals(eventItem2.getEvent(), TestVariables.event2);
+    }
+
+    @Test
+    public void getIdx() {
+        assertEquals(eventItem1.getIdx(), 0);
+        assertEquals(eventItem2.getIdx(), 1);
+    }
+}

--- a/app/src/test/java/com/example/sep/viewModel/EventViewModelTest.java
+++ b/app/src/test/java/com/example/sep/viewModel/EventViewModelTest.java
@@ -1,0 +1,47 @@
+package com.example.sep.viewModel;
+
+import static org.junit.Assert.*;
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import com.example.sep.TestVariables;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+public class EventViewModelTest {
+
+    private EventViewModel eventVM;
+
+
+    @Rule
+    public TestRule rule = new InstantTaskExecutorRule();
+
+    @Before
+    public void init() {
+        eventVM = new EventViewModel();
+    }
+
+    @Test
+    public void getEvent() {
+        assertNull(eventVM.getEvent().getValue());
+    }
+
+    @Test
+    public void setEvent() {
+    }
+
+    @Test
+    public void setIdentifier() {
+        eventVM.setIdentifier(3);
+        assertEquals(eventVM.identifier, 3);
+    }
+
+    @Test
+    public void getIdentifier() {
+        eventVM.setIdentifier(4);
+        assertEquals(eventVM.getIdentifier(), 4);
+    }
+}


### PR DESCRIPTION
The PR includes:

- the form to create a financial request (including safety features to make sure all fields are filled)
- the financial request is saved into the local storage
- the financial requests can be viewed in a recyclerview
- the financial requests can be deleted
- the data in the event and financial request details are viewed on the UI with data binding (instead of `findViewById` and `textView.setText(...)` --> makes the code in the fragment less cluttery
- some tests, but not all of them, bc I can't figure out how to tests ViewModels and if I have to test one more get/set function imma go ballistic :exploding_head: 
- a cool way of having different bottom navigation menus in the BaseActivity depending on what is the role of the user (for instance the financial manager will have to be able to view both the recycler views with events, and the recycler views with tasks)

Not included in this PR:

- the record number of the financial request needs to be linked from the task (waiting on the task recycler view before that one)
- the logic of who can view and make financial requests (right now the financial manager is the only one able to view and create financial requests, but that's good for testing, so we can leave it like that for now, and only deal with that once refining the logic of who can view what)
- UI can be optimized, but there is no sense in making that before linking the tasks and financial requests together
- requests cannot be approved yet 